### PR TITLE
Fix .env.example ZONE_ID placeholder

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
 CLOUDFLARE_API_TOKEN=<TOKEN>
-ZONE_ID=ZINE_ID
+ZONE_ID=<ZONE_ID>
 DNS_RECORD_NAME=home.myowndmain.com
 LOG_FILE=/var/log/cloudflare-ddns.log


### PR DESCRIPTION
## Summary
- update `.env.example` to use a placeholder for ZONE_ID instead of the malformed value

## Testing
- `python -m py_compile ddns.py`


------
https://chatgpt.com/codex/tasks/task_e_68489234d6188331b8f2ab0b5828b331