### PR TITLE
Fix domain placeholder in .env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
 CLOUDFLARE_API_TOKEN=<TOKEN>
 ZONE_ID=<ZONE_ID>
-DNS_RECORD_NAME=home.myowndmain.com
+DNS_RECORD_NAME=home.mydomain.com
 LOG_FILE=/var/log/cloudflare-ddns.log


### PR DESCRIPTION
## Summary
- correct the sample domain in `.env.example`

## Testing
- `python3 -m py_compile ddns.py`

------
https://chatgpt.com/codex/tasks/task_e_684893ff3b748331b0d0daeea89779a1